### PR TITLE
Added ability to specify `useActive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ Now you can edit the commands you want:
 ```
 
 ### Properties
-| Property | Description                                                                                                   |
-|----------|---------------------------------------------------------------------------------------------------------------|
-| command  | The text to send to the terminal.                                                                             |
-| auto     | Whether to add a new line to the text being sent, this is normally required to run a command in the terminal. |
-| preserve | Don't dispose of terminal running this command.                                                               |
-| name     | Name for the command. A human readable string which is rendered prominent.                                    |
-| group    | Commands sharing the group name will be grouped together in the menu.                                         |
+| Property       | Description                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------------|
+| command        | The text to send to the terminal.                                                                             |
+| auto           | Whether to add a new line to the text being sent, this is normally required to run a command in the terminal. |
+| useActive      | Use current active terminal instead of launching a new one.                                                   |
+| preserve       | Don't dispose of terminal running this command. Coerced to true if useActive true.                            |
+| name           | Name for the command. A human readable string which is rendered prominent.                                    |
+| group          | Commands sharing the group name will be grouped together in the menu.                                         |
 
 ### Variables
 | Variable    | Description                                                                                                |

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,6 +1,7 @@
 export interface TerminalCommand {
     command: string;
     auto: boolean;
+    useActive: boolean;
     preserve: boolean;
     name?: string;
     group?: string;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -23,7 +23,8 @@ function sanitizeConfiguration(configuration: any) {
             return {
                 command: maybeCommand.command,
                 auto: !!maybeCommand.auto,
-                preserve: !!maybeCommand.preserve,
+                useActive: !!maybeCommand.useActive,
+                preserve: (!!maybeCommand.preserve || !!maybeCommand.useActive),
                 name: notEmptyStringOrUndefined(maybeCommand.name),
                 group: notEmptyStringOrUndefined(maybeCommand.group)
             };

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4,14 +4,20 @@ import { TerminalCommand } from './command';
 let previousTerminal: vscode.Terminal | undefined;
 
 export async function runCommand(command: TerminalCommand, cwd?: string, resource?: string) {
-    const terminal = vscode.window.createTerminal({ cwd: cwd });
-    terminal.show();
+    // if useActive option true, use current terminal instead of creating new
+    let terminal: vscode.Terminal | undefined;
+    if (command.useActive) {
+        terminal = vscode.window.activeTerminal;
+    } else {
+        terminal = vscode.window.createTerminal({ cwd: cwd });
+    };
+    terminal!.show();
 
     ensureDisposed();
 
     const result = await insertVariables(command.command, resource);
 
-    terminal.sendText(result.command, command.auto && result.successful);
+    terminal!.sendText(result.command, command.auto && result.successful);
 
     if (!command.preserve) {
         previousTerminal = terminal;

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -6,7 +6,7 @@ let previousTerminal: vscode.Terminal | undefined;
 export async function runCommand(command: TerminalCommand, cwd?: string, resource?: string) {
     // if useActive option true, use current terminal instead of creating new
     let terminal: vscode.Terminal | undefined;
-    if (command.useActive) {
+    if (command.useActive && !!vscode.window.activeTerminal) {
         terminal = vscode.window.activeTerminal;
     } else {
         terminal = vscode.window.createTerminal({ cwd: cwd });


### PR DESCRIPTION
Added useActive command input in order to utilize current terminal instead of making a new one
Default to false results in current functionality unchanged
If set to true, sets target to current terminal instead of creating new